### PR TITLE
dev/WP/feature#15 - configuracao git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+#firebase
+android/app/google-services.json
+ios/firebase_app_id_file.json
+ios/Runner/GoogleServices-Info.plist
+lib/firebase_options.dart


### PR DESCRIPTION
Efetuado configuração do Git Ignore para que não suba arquivos indevidos ao configurar o firebase no projeto.